### PR TITLE
AMB-952 fix int base URL documentation

### DIFF
--- a/specification/booking-and-referral.yaml
+++ b/specification/booking-and-referral.yaml
@@ -20,7 +20,7 @@ info:
       * we expect to make breaking changes based on developer feedback
     
     ### Roadmap
-    To see our roadmap, or to suggest, comment or vote on features for this API, see our [interactive product backlog](https://nhs-digital-api-management.featureupvote.com/?order=popular&filter=allexceptdone&tag=fhir-converter&deleted=0#controls).
+    To see our roadmap, or to suggest, comment or vote on features for this API, see our [interactive product backlog](https://nhs-digital-api-management.featureupvote.com/?order=popular&filter=allexceptdone&tag=booking-and-referral&deleted=0#controls).
     If you have any other queries, please [contact us](https://digital.nhs.uk/developer/help-and-support).
     
     ## Technology
@@ -50,7 +50,7 @@ info:
     ### Environments and testing
     | Environment       | Base URL                                                               |
     | ----------------- | ---------------------------------------------------------------------- |
-    | Integration test  | `https://int.api.service.nhs.uk/fhir-converter`                        |
+    | Integration test  | `https://int.api.service.nhs.uk/booking-and-referral/FHIR/R4`                        |
     | Production        | Not yet available                                                      |
     
     Our [integration test environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing):


### PR DESCRIPTION
## Summary
Int base url was pointing to "fhir-converter" in some of the spec descriptions.
This was an obvious typo.
This PR amend the affected documentation to point to 'booking-and-referral/FHIR/R4'


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
